### PR TITLE
Adding option to just use the OpenAI url for the preview images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,9 @@ FROM selenium/standalone-chrome
 
 USER root
 
-RUN apt update && apt install -y python3 python3-pip
+RUN apt update && apt install -y python3 python3-pip zsh git curl wget vim
 COPY requirements.txt requirements.txt
+
 # create venv, activate it, and install requirements
 RUN apt-get update && apt-get install -y python3-venv
 RUN python3 -m venv venv_container && \

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Furthermore, you have to set the following environment variables in a `.env` fil
 ALSTERFOOD_WEBSITE_URL="https://desy.myalsterfood.de/"
 OPENAI_API_KEY="<your OpenAI API key>"
 MATTERMOST_WEBHOOK_URL="<your Mattermost webhook URL>"
+USE_OPENAI_IMAGES_URL="<if set to 'true', the bot will use the OpenAI image API to generate images (which expire after 1 hour)>"
 IMAGE_CLOUD_UPLOAD_URL="<your image cloud upload URL>"
 IMAGE_CLOUD_UPLOAD_TOKEN="<your image cloud upload token>"
 IMAGE_CLOUD_DOWNLOAD_URL="<your image cloud download URL>"


### PR DESCRIPTION
This PR adds an option to just use the image URL that is returned by the openai API.
Those URLs expire after one hour, but in case DESY Sync&Share is down, this is a nice fallback option.